### PR TITLE
Clicking on a tag when typing results in the typed text being entered, not the clicked tag

### DIFF
--- a/superbly-tagfield.js
+++ b/superbly-tagfield.js
@@ -118,6 +118,7 @@
         });
 
 		if (addItemOnBlur) {
+			currentItem = $(e.target).parent().find('.superblySuggestItem:hover').html();
 			tagInput.blur(function(e){
 				checkForItem();
 			});

--- a/superbly-tagfield.js
+++ b/superbly-tagfield.js
@@ -8,15 +8,15 @@
  * http://www.superbly.ch/licenses/gpl-2.0.txt
  *
  * Date: 27-11-2011
- */
+*/
 (function($){
     $.fn.superblyTagField = function(userOptions) {
         var settings = {
-        	caseSensitive:true,
+            caseSensitive:true,
             allowNewTags:true,
             allowedTagsNumber:false,
             showTagsNumber:10,
-			addItemOnBlur:false,
+            addItemOnBlur:false,
             preset:[],
             tags:[]
         };
@@ -45,7 +45,7 @@
         var allowNewTags = settings.allowNewTags;
         var allowedTagsNumber = settings.allowedTagsNumber;
         var showTagsNumber = settings.showTagsNumber;
-		var addItemOnBlur = settings.addItemOnBlur;
+        var addItemOnBlur = settings.addItemOnBlur;
 
         var tagstmp = tags.slice();
 
@@ -73,23 +73,23 @@
 
         // events
         suggestList.mouseover(function(e){
-            hoverSuggestItems = true; 
+            hoverSuggestItems = true;
         });
 
         suggestList.mouseleave(function(e){
-            hoverSuggestItems = false; 
+            hoverSuggestItems = false;
         });
 
         tagInput.keyup(function(e){
-        	if((allowedTagsNumber == false) || (inserted.length < allowedTagsNumber)){
-            	suggest($(this).val());
+            if((allowedTagsNumber == false) || (inserted.length < allowedTagsNumber)){
+                suggest($(this).val());
             }
         });
 
         tagInput.focusout(function(e){
             if(!hoverSuggestItems){
                 suggestList.css('display', 'none');
-            } 
+            }
         });
 
         tagInput.focus(function(e){
@@ -97,14 +97,14 @@
         });
 
         tagInput.keydown(function(e){
-            if(e.keyCode == keyMap.downArrow) {		
+            if(e.keyCode == keyMap.downArrow) {
                 selectDown();
             }else if(e.keyCode == keyMap.upArrow) {
                 selectUp()
             }else if(e.keyCode == keyMap.enter || e.keyCode == keyMap.tab) {
                 checkForItem();
                 // prevent default action for enter
-                return e.keyCode != keyMap.enter; 
+                return e.keyCode != keyMap.enter;
             }else if(e.keyCode == keyMap.backspace){
                 // backspace
                 if(tagInput.val() == ''){
@@ -117,28 +117,29 @@
 
         });
 
-		if (addItemOnBlur) {
-			currentItem = $(e.target).parent().find('.superblySuggestItem:hover').html();
-			tagInput.blur(function(e){
-				checkForItem();
-			});
-		}
+        if (addItemOnBlur) {
+
+            currentItem = $(e.target).parent().find('.superblySuggestItem:hover').html();
+            tagInput.blur(function(e){
+                checkForItem();
+            });
+        }
 
         tagList.parent().click(function(e){
-            tagInput.focus();	
+            tagInput.focus();
         });
 
-        // functions 
+        // functions
         function setValue(){
             tagField.val(inserted.join(','));
         }
 
         function updateTagInputWidth()
         {
-            /* 
+            /*
             * To make tag wrapping behave as expected, dynamically adjust
             * the tag input's width to its content's width
-            * The best way to get the content's width in pixels is to add it 
+            * The best way to get the content's width in pixels is to add it
             * to the DOM, grab the width, then remove it from the DOM.
             */
             var temp = $("<span />").text(tagInput.val()).appendTo(inputItem);
@@ -147,13 +148,13 @@
             tagInput.width(width + 20);
         }
 
-		function checkForItem(value){
-			if(allowedTagsNumber != false){
-				if(inserted.length >= allowedTagsNumber){
-					return;
-				}
-			}
-			if(currentItem != null){
+        function checkForItem(value){
+            if(allowedTagsNumber != false){
+                if(inserted.length >= allowedTagsNumber){
+                    return;
+                }
+            }
+            if(currentItem != null){
                 addItem(currentItem);
             } else if(allowNewTags){
                 var value = tagInput.val();
@@ -161,21 +162,21 @@
                     addItem(value);
                 }
             }
-		}
-		
-		function addItem(value){  
-			 addItemWithFocus(value,true); 
-		}
+        }
 
-        function addItemWithFocus(value,setFocusToInputField){          
+        function addItem(value){
+            addItemWithFocus(value,true);
+        }
+
+        function addItemWithFocus(value,setFocusToInputField) {
             var caseInSensitiveFound = false;
             if(!caseSensitive){
-				$.each(inserted,function(index, val) { 
-  					if (caseInSensitiveFound == false && (val.toLowerCase() == value.toLowerCase())) {
-   						caseInSensitiveFound = true;
-   					 	return true;
-  					}
-				});
+                $.each(inserted,function(index, val) {
+                    if (caseInSensitiveFound == false && (val.toLowerCase() == value.toLowerCase())) {
+                        caseInSensitiveFound = true;
+                        return true;
+                    }
+                });
             }
             var index = jQuery.inArray(value,tagstmp);
             if((jQuery.inArray(value,inserted) == -1) && ( index > -1 || allowNewTags) && !caseInSensitiveFound){
@@ -188,7 +189,7 @@
                 tagInput.val("");
                 currentValue = null;
                 currentItem = null;
-                // add remove click event 
+                // add remove click event
                 var new_index = tagList.children('.superblyTagItem').size()-1;
                 $(tagList.children('.superblyTagItem')[new_index]).children('a').click(function(e){
                     var value = $($(this).parent('.superblyTagItem').children('span')[0]).text();
@@ -198,22 +199,22 @@
             suggestList.css('display', 'none');
             updateTagInputWidth();
             if(setFocusToInputField){
-            	tagInput.focus();
+                tagInput.focus();
             }
             setValue();
             if((allowedTagsNumber != false) && (inserted.length >= allowedTagsNumber)){
-				disableAddItem()
-			}
+                disableAddItem()
+            }
         }
-        
+
         function disableAddItem(){
-        	tagInput.attr('disabled','disabled');
-			suggestList.css('display','none');
+            tagInput.attr('disabled','disabled');
+            suggestList.css('display','none');
         }
-        
+
         function enableAddItem(){
-        	tagInput.removeAttr('disabled');
-			suggestList.show();
+            tagInput.removeAttr('disabled');
+            suggestList.show();
         }
 
 
@@ -232,8 +233,8 @@
             tagInput.focus();
             setValue();
             if((allowedTagsNumber != false) && (inserted.length < allowedTagsNumber)){
-				enableAddItem();
-			}
+                enableAddItem();
+            }
         }
 
         function removeLastItem(){
@@ -283,7 +284,7 @@
             selectedIndex=null;
             if(!allowNewTags){
                 selectedIndex=0;
-                $(suggestionItems[selectedIndex]).addClass("selected");	
+                $(suggestionItems[selectedIndex]).addClass("selected");
                 currentItem = $(suggestionItems[selectedIndex]).html();
             }
         }


### PR DESCRIPTION
This patch sets the currentItem to the tag that was selected when the blur event fires, which allows addItem to work properly.

I standardized whitespace to 4 tags, as that was the prevalent style throughout the doc as well. Feel free to reject that commit if you don't want it.
